### PR TITLE
[`pylint`] implement `PLR0401 (cyclic-import)` using `par_iter`

### DIFF
--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -1,3 +1,6 @@
+use rustc_hash::{FxHashSet, FxHashMap};
+
+use ruff_python_ast::imports::{ImportMap, ModuleMapping};
 use ruff_python_semantic::analyze::function_type;
 use ruff_python_semantic::analyze::function_type::FunctionType;
 use ruff_python_semantic::scope::{FunctionDef, ScopeKind};
@@ -34,4 +37,24 @@ pub fn in_dunder_init(checker: &Checker) -> bool {
         return false;
     }
     true
+}
+
+#[derive(Default)]
+pub struct CyclicImportHelper<'a> {
+    pub cycles: FxHashMap<u32, FxHashSet<Vec<u32>>>,
+    pub module_mapping: ModuleMapping<'a>,
+}
+
+impl<'a> CyclicImportHelper<'a> {
+    pub fn new(import_map: &'a ImportMap) -> Self {
+        let mut module_mapping = ModuleMapping::new();
+        import_map.module_to_imports.keys().for_each(|module| {
+            module_mapping.insert(module);
+        });
+
+        Self {
+            cycles: FxHashMap::default(),
+            module_mapping,
+        }
+    }
 }

--- a/crates/ruff/src/rules/pylint/mod.rs
+++ b/crates/ruff/src/rules/pylint/mod.rs
@@ -1,5 +1,6 @@
 //! Rules from [Pylint](https://pypi.org/project/pylint/).
 mod helpers;
+pub use helpers::CyclicImportHelper as CyclicImportHelper;
 pub(crate) mod rules;
 pub use rules::cyclic_import as pylint_cyclic_import;
 pub mod settings;

--- a/crates/ruff_python_ast/src/imports.rs
+++ b/crates/ruff_python_ast/src/imports.rs
@@ -1,5 +1,5 @@
 use ruff_text_size::TextRange;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -168,7 +168,7 @@ impl<'a> ModuleMapping<'a> {
         }
     }
 
-    pub(super) fn insert(&mut self, module: &'a str) {
+    pub fn insert(&mut self, module: &'a str) {
         self.module_to_id.insert(module, self.id);
         self.id_to_module.push(module);
         self.id += 1;
@@ -180,25 +180,5 @@ impl<'a> ModuleMapping<'a> {
 
     pub fn to_module(&self, id: &u32) -> Option<&&str> {
         self.id_to_module.get(*id as usize)
-    }
-}
-
-#[derive(Default)]
-pub struct CyclicImportHelper<'a> {
-    pub cycles: FxHashMap<u32, FxHashSet<Vec<u32>>>,
-    pub module_mapping: ModuleMapping<'a>,
-}
-
-impl<'a> CyclicImportHelper<'a> {
-    pub fn new(import_map: &'a ImportMap) -> Self {
-        let mut module_mapping = ModuleMapping::new();
-        import_map.module_to_imports.keys().for_each(|module| {
-            module_mapping.insert(module);
-        });
-
-        Self {
-            cycles: FxHashMap::default(),
-            module_mapping,
-        }
     }
 }


### PR DESCRIPTION
Use a `RwLock` to allow for checking of cyclic imports using `par_iter`.
I tested this on v3.11.3 of the cpython repo.

```
 Performance counter stats for 'target/release/ruff_cyclic_import_head check --no-cache --select=PLR0401 /home/chris/projects/cpython/' (100 runs):

           3318.48 msec task-clock:u              #   18.442 CPUs utilized            ( +-  0.35% )
                 0      context-switches:u        #    0.000 /sec
                 0      cpu-migrations:u          #    0.000 /sec
             17670      page-faults:u             #    5.345 K/sec                    ( +-  0.99% )
   <not supported>      cycles:u
   <not supported>      instructions:u
   <not supported>      branches:u
   <not supported>      branch-misses:u

          0.179937 +- 0.000744 seconds time elapsed  ( +-  0.41% )

 Performance counter stats for 'target/release/ruff --no-cache --select=PLR0401 /home/chris/projects/cpython/' (100 runs):

           3206.41 msec task-clock:u              #   18.557 CPUs utilized            ( +-  0.33% )
                 0      context-switches:u        #    0.000 /sec
                 0      cpu-migrations:u          #    0.000 /sec
             15817      page-faults:u             #    4.793 K/sec                    ( +-  1.11% )
   <not supported>      cycles:u
   <not supported>      instructions:u
   <not supported>      branches:u
   <not supported>      branch-misses:u

          0.172784 +- 0.000749 seconds time elapsed  ( +-  0.43% )
```

It's _very_ marginally faster; tested on an AMD 5900X using perf that I compiled on WSL2.